### PR TITLE
Update example - prop.text has been changed to label.text

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,13 @@ let view (model:Model) (dispatch:Msg->unit) =
                 prop.position.y.at 1
                 prop.textAlignment.centered
                 prop.color (Color.BrightYellow, Color.Green)
-                prop.text "'F#ncy' Counter!"
+                label.text "'F#ncy' Counter!"
             ] 
 
             View.button [
                 prop.position.x.center
                 prop.position.y.at 5
-                prop.text "Up"
+                label.text "Up"
                 button.onClick (fun () -> dispatch Increment)
             ] 
 
@@ -145,35 +145,35 @@ let view (model:Model) (dispatch:Msg->unit) =
                 prop.position.y.at (y + 10)
                 prop.textAlignment.centered
                 prop.color (Color.Magenta, Color.BrightYellow)
-                prop.text $"The Count of 'Fancyness' is {model.Counter}"
+                label.text $"The Count of 'Fancyness' is {model.Counter}"
             ] 
 
 
             View.button [
                 prop.position.x.center
                 prop.position.y.at 7
-                prop.text "Down"
+                label.text "Down"
                 button.onClick (fun () -> dispatch Decrement)
             ] 
 
             View.button [
                 prop.position.x.center
                 prop.position.y.at 9
-                prop.text "Start Spinning"
+                label.text "Start Spinning"
                 button.onClick (fun () -> dispatch StartSpin)
             ] 
 
             View.button [
                 prop.position.x.center
                 prop.position.y.at 11
-                prop.text "Stop Spinning"
+                label.text "Stop Spinning"
                 button.onClick (fun () -> dispatch StopSpin)
             ] 
 
             View.button [
                 prop.position.x.center
                 prop.position.y.at 13
-                prop.text "Reset"
+                label.text "Reset"
                 button.onClick (fun () -> dispatch Reset)
             ]
         ]
@@ -201,7 +201,7 @@ use `prop.ref (fun view -> ...)`
 View.button [
     prop.position.x.center
     prop.position.y.at 13
-    prop.text "Reset"
+    label.text "Reset"
     button.onClick (fun () -> dispatch Reset)
     prop.ref (fun view -> myButtonRef <- (view :?> Terminal.Gui.Button).xxxx // do your stuff here)
 ]


### PR DESCRIPTION
The example in the README did not compile with the latest nuget package.
Updated it to use label.text and it seems to run fine.